### PR TITLE
Remove role from template

### DIFF
--- a/django_cradmin/locale/en/LC_MESSAGES/django.po
+++ b/django_cradmin/locale/en/LC_MESSAGES/django.po
@@ -459,7 +459,7 @@ msgstr ""
 
 #: templates/django_cradmin/missing_role.django.html:12
 #, python-format
-msgid "You do not have permission to administer \"%(what)s\"."
+msgid "You do not have permission to administer this page."
 msgstr ""
 
 #: templates/django_cradmin/pagepreview/includes/pagepreview-fullsize-iframe-wrapper.django.html:25

--- a/django_cradmin/locale/nb/LC_MESSAGES/django.po
+++ b/django_cradmin/locale/nb/LC_MESSAGES/django.po
@@ -485,9 +485,9 @@ msgstr "Ingen tilgang"
 
 #: templates/django_cradmin/missing_role.django.html:12
 #, python-format
-msgid "You do not have permission to administer \"%(what)s\"."
+msgid "You do not have permission to administer this page."
 msgstr ""
-"Du har ikke de nødvendige rettighetene for å administrere \"%(what)s\"."
+"Du har ikke de nødvendige rettighetene for å administrere denne siden."
 
 #: templates/django_cradmin/pagepreview/includes/pagepreview-fullsize-iframe-wrapper.django.html:25
 msgid "Close preview"

--- a/django_cradmin/templates/django_cradmin/missing_role.django.html
+++ b/django_cradmin/templates/django_cradmin/missing_role.django.html
@@ -9,7 +9,7 @@
     <div class="adminui-page-section adminui-page-section--center-md">
         <div class="container container--tight">
             <p>
-                {% blocktrans with what=role %}You do not have permission to administer "{{what}}".{% endblocktrans %}
+                {% blocktrans %}You do not have permission to administer this page.{% endblocktrans %}
             </p>
         </div>
     </div>


### PR DESCRIPTION
The role can contain sensetive information, and makes it possible to
iterate over the roles of the webpage.

Signed-off-by: Morten Linderud <morten@linderud.pw>